### PR TITLE
make the progress outline visible in dark mode

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -85,3 +85,7 @@ input {
 #commands .buttons button:hover {
   background-color: #fff;
 }
+
+.progress-bar {
+  border-color: #aaa;
+}

--- a/css/dark.css
+++ b/css/dark.css
@@ -87,5 +87,5 @@ input {
 }
 
 .progress-bar {
-  border-color: #aaa;
+  border-color: #fff;
 }

--- a/css/light.css
+++ b/css/light.css
@@ -73,3 +73,7 @@ input, select, button {
   background-color: #333;
   color: #fff;
 }
+
+.progress-bar {
+  border-color: #333;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -348,7 +348,6 @@ div.clear {
   height: 24px;
   border-style: solid;
   border-width: 2px;
-  border-color: #333;
   border-radius: 10px;
   padding: 0;
   overflow: hidden;


### PR DESCRIPTION
This is a small tweak to make the progress bar outline easier to see in the dark mode.

I tried to run this locally to test using python with this command:
```
python -m http.server
```
The page does not seem to load correctly for me when I do it that way though. I think it may be trying to automatically upgrade the traffic to https which I don't have a cert for locally.

 I'm not sure what the proper way to run this locally for testing is. But I will test this out if you can point me in the right direction for that.