### PR TITLE
Increased timeout to reduce errors

### DIFF
--- a/js/esptool.js
+++ b/js/esptool.js
@@ -944,7 +944,7 @@ class EspLoader {
     this.logMsg("Running stub...")
     await this.memFinish(stub['entry']);
 
-    let p = await this.readBuffer(100);
+    let p = await this.readBuffer(500);
     p = String.fromCharCode(...p);
 
     if (p != 'OHAI') {

--- a/js/script.js
+++ b/js/script.js
@@ -460,7 +460,7 @@ function toggleUIConnected(connected) {
 function loadAllSettings() {
   // Load all saved settings or defaults
   autoscroll.checked = loadSetting('autoscroll', true);
-  baudRate.value = loadSetting('baudrate', 921600);
+  baudRate.value = loadSetting('baudrate', baudRates[0]);
   darkMode.checked = loadSetting('darkmode', false);
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -143,8 +143,9 @@ function debugMsg(...args) {
   function getStackTrace() {
     let stack = new Error().stack;
     stack = stack.split("\n").map(v => v.trim());
-    stack.shift();
-    stack.shift();
+    for (let i=0; i<3; i++) {
+        stack.shift();
+    }
 
     let trace = [];
     for (let line of stack) {


### PR DESCRIPTION
This makes it more reliable on ESP32. This is needed to get the NVM Generator code working.