### PR TITLE
Update Github Workflow to use Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm ci
       - run: script/build
       - run: npm exec -- prettier --check src

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: install node v16
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Install Yarn with NPM
         run: npm install -g yarn
       - name: yarn install


### PR DESCRIPTION
Resolves issue in one of the actions runs with this result:
```
Run yarn install
yarn install v1.22.19
info No lockfile found.
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/[4](https://github.com/adafruit/Adafruit_WebSerial_ESPTool/actions/runs/6471634675/job/17570479281#step:5:5)] Resolving packages...
[2/4] Fetching packages...
error rollup@4.0.2: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "1[6](https://github.com/adafruit/Adafruit_WebSerial_ESPTool/actions/runs/6471634675/job/17570479281#step:5:7).20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```