### PR TITLE
Add release drafter back in that was accidentally removed

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,9 @@
+categories:
+  - title: "⬆️ Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         // In development we import locally.
         window.location.hostname === "localhost"
           ? "/dist/web/index.js"
-          : "https://cdn.jsdelivr.net/gh/adafruit/Adafruit_WebSerial_ESPTool@1.1.0/dist/web/index.js"
+          : "https://cdn.jsdelivr.net/gh/adafruit/Adafruit_WebSerial_ESPTool@1.2.0/dist/web/index.js"
       );
     </script>
     <script src="js/script.js" module defer></script>


### PR DESCRIPTION
I think it was either accidentally removed or removed for some reason that I don't recall. Either way, it should be added back in because other repos depend on it.