### PR TITLE
fix : Passthrough logic inside hardReset()

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -46,7 +46,10 @@ document.addEventListener("DOMContentLoaded", () => {
   autoscroll.addEventListener("click", clickAutoscroll);
   baudRate.addEventListener("change", changeBaudRate);
   darkMode.addEventListener("click", clickDarkMode);
-  noReset.addEventListener("click", clickNoReset);
+  noReset.addEventListener("change", () => {
+    console.log("Checkbox changed:", noReset.checked); // Log checkbox state changes
+  });
+
   window.addEventListener("error", function (event) {
     console.log("Got an uncaught error: ", event.error);
   });
@@ -248,15 +251,8 @@ async function clickDarkMode() {
  * Change handler for ESP32 co-processor boards
  */
 async function clickNoReset() {
+  console.log("Checkbox state:", noReset.checked); // Debugging output
   saveSetting("noReset", noReset.checked);
-  if (espStub) {
-    try {
-      // Assuming espStub has a setNoReset method, similar to setBaudrate
-      await espStub.setNoReset(noReset.checked);
-    } catch (error) {
-      console.error("Failed to set noReset:", error);
-    }
-  }
 }
 
 /**

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -164,10 +164,11 @@ export class ESPLoader extends EventTarget {
   }
 
   async hardReset(bootloader = false) {
-
     // Passthrough mode defaults to "off"
     // Passthrough checkbox is "on" will prevent a controller reset
-    const noResetCheckbox = document.getElementById("noReset") as HTMLInputElement;
+    const noResetCheckbox = document.getElementById(
+      "noReset",
+    ) as HTMLInputElement;
     const noReset = noResetCheckbox ? noResetCheckbox.checked : false;
 
     if (noReset) {

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -164,17 +164,14 @@ export class ESPLoader extends EventTarget {
   }
 
   async hardReset(bootloader = false) {
-    this.logger.log("Try hard reset.");
 
-    // Check for noReset toggle
-    const noResetCheckbox = document.getElementById("noReset");
-    const noResetEnabled = noResetCheckbox
-      ? (noResetCheckbox as HTMLInputElement).checked
-      : false;
+    // Passthrough mode defaults to "off"
+    // Passthrough checkbox is "on" will prevent a controller reset
+    const noResetCheckbox = document.getElementById("noReset") as HTMLInputElement;
+    const noReset = noResetCheckbox ? noResetCheckbox.checked : false;
 
-    if (noResetEnabled) {
-      this.logger.log("No reset requested; skipping hard reset.");
-      return; // Skip reset if noReset is enabled
+    if (noReset) {
+      return; // Skip reset if noReset is true
     }
 
     if (bootloader) {


### PR DESCRIPTION
A small change to read the Passthrough checkbox state directly inside of hardReset(). This is to avoid issuing a reset on passthrough boards (M4 + ESP coprocessor).

This was tested locally, but I believe by forcing a read of the passthrough checkbox the web hosted code will also work. 

Hardware successfully tested with this update:

Feather V2
PyPortal

Low risk level of making things worse. The Webserial_ESPTool has not worked in passthrough mode since August 2024. 
