### PR TITLE
fix : jsdelivr updated to current release

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         // In development we import locally.
         window.location.hostname === "localhost"
           ? "/dist/web/index.js"
-          : "https://cdn.jsdelivr.net/gh/adafruit/Adafruit_WebSerial_ESPTool@1.2.0/dist/web/index.js"
+          : "https://cdn.jsdelivr.net/gh/adafruit/Adafruit_WebSerial_ESPTool@1.3.0/dist/web/index.js"
       );
     </script>
     <script src="js/script.js" module defer></script>


### PR DESCRIPTION
hardcoded release version was pointing to pre-passthrough code.

@dhalbert - hardcoded line in index.html was pointing to an earlier release of WebSerial.

```
"https://cdn.jsdelivr.net/gh/adafruit/Adafruit_WebSerial_ESPTool@1.3.0/dist/web/index.js"
```