### PR TITLE
Fixes the passthrough updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       <div class="subheader">
         <div class="title left">Adafruit ESPTool</div>
         <div class="right">
-          <label for="noReset"> Turn on for Passthrough updates</label>
+          <label for="noReset"> No reset for Passthrough updates</label>
           <div class="onoffswitch" style="margin-right: 30px;">
             <input
               type="checkbox"

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
-import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.3/bundle.js";
+//import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.3/bundle.js";
+import { ESPLoader, Transport } from "./esptool-js/bundle.js";
 
 const baudRates = [921600, 115200, 230400, 460800];
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
-//import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.3/bundle.js";
-import { ESPLoader, Transport } from "./esptool-js/bundle.js";
+import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.4/bundle.js";
+//import { ESPLoader, Transport } from "./esptool-js/bundle.js";
 
 const baudRates = [921600, 115200, 230400, 460800];
 

--- a/js/script.js
+++ b/js/script.js
@@ -135,25 +135,34 @@ function enableStyleSheet(node, enabled) {
  * Click handler for the connect/disconnect button.
  */
 async function clickConnect() {
+    // Disconnect if connected
     if (transport !== null) {
         await transport.disconnect();
         await transport.waitForUnlock(1500);
         toggleUIConnected(false);
         transport = null;
-        device = null;
+        if (device !== null) {
+            await device.close();
+            device = null;
+        }
         chip = null;
         return;
     }
 
+    // Set up device and transport
     if (device === null) {
         device = await serialLib.requestPort({});
+    }
+
+    if (transport === null) {
         transport = new Transport(device, true);
     }
 
     try {
+        const romBaudrate = parseInt(baudRate.value);
         const loaderOptions = {
             transport: transport,
-            baudrate: parseInt(baudRate.value),
+            baudrate: romBaudrate,
             terminal: espLoaderTerminal,
             debugLogging: false,
         };
@@ -163,14 +172,21 @@ async function clickConnect() {
         let resetMode = "default_reset";
         if (noReset.checked) {
             resetMode = "no_reset";
+            try {
+                // Initiate passthrough serial setup
+                await transport.connect(romBaudrate);
+                await transport.disconnect();
+                await sleep(350);
+            } catch (e) {
+            }
         }
+
         chip = await esploader.main(resetMode);
 
         // Temporarily broken
         // await esploader.flashId();
         toggleUIConnected(true);
         toggleUIToolbar(true);
-
 
     } catch (e) {
         console.error(e);


### PR DESCRIPTION
Now the airlift updates using the passthrough script actually work. This uses the latest esptool-js, which implements reset modes and has a little code in here to delay connecting through the board to allow the passthrough script to get into the correct mode. The option name is the UI is also changed a bit to make more sense.