### PR TITLE
Change page title from "Adafruit ESPTool" to "Adafruit WebSerial ESPTool"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Adafruit ESPTool</title>
+    <title>Adafruit WebSerial ESPTool</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -50,7 +50,7 @@
         you're running Chrome 89 or later.
       </div>
       <div class="subheader">
-        <div class="title left">Adafruit ESPTool</div>
+        <div class="title left">Adafruit WebSerial ESPTool</div>
         <div class="right">
           <label for="noReset"> No reset for Passthrough updates</label>
           <div class="onoffswitch" style="margin-right: 30px;">


### PR DESCRIPTION
This tool is referred to many places as the **WebSerial ESPTool** or sometimes the **Adafruit WebSerial ESPTool**. However, the page title is currently just **Adafruit ESPTool**. `WebSerial` is also part of the URL, and it even says that in the log output.

I just finished revising the Factory Reset page template ([example](https://learn.adafruit.com/adafruit-esp32-s3-feather/factory-reset)) for all the ESP32-S2/S3 boards. I changed the references to the tool to **Adafruit ESPTool**, to match the visible page title. However, I've found other references in other guides, and I'm wondering if it would be better to make the page title match the documentation in more places. It's also more precise, because adding "**WebSerial**" makes it more clear it's not like `esptool.py`. I'm happy to re-revise

The disadvantage of changing the title is that it no longer quite matches the screenshots. But it's not a big change, and I don't think it's too confusing. Some screenshots need updating anyway because they don't include the passthrough title. So we can update the screenshots as needed.

What do you think?